### PR TITLE
Fix: `canvas` class bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasis-engine/miniprogram-adapter",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "adapter of miniprogram",
   "keywords": [
     "webgl",

--- a/src/HTMLCanvasElement.ts
+++ b/src/HTMLCanvasElement.ts
@@ -1,1 +1,1 @@
-export const HTMLCanvasElement = Object;
+export class HTMLCanvasElement extends Object {}

--- a/src/HTMLCanvasElement.ts
+++ b/src/HTMLCanvasElement.ts
@@ -1,1 +1,3 @@
-export class HTMLCanvasElement extends Object {}
+import { HTMLElement } from ".";
+
+export class HTMLCanvasElement extends HTMLElement {}

--- a/src/HTMLElement.ts
+++ b/src/HTMLElement.ts
@@ -4,8 +4,6 @@ import { Element } from "./Element";
 function noop() {}
 
 export class HTMLElement extends Element {
-  className: string;
-  children: Array<any>;
   focus: any;
   blur: any;
   insertBefore: any;

--- a/src/OffscreenCanvas.ts
+++ b/src/OffscreenCanvas.ts
@@ -1,1 +1,1 @@
-export const OffscreenCanvas = Object;
+export class OffscreenCanvas extends Object {}


### PR DESCRIPTION
按照之前的写法，任何实例 instanceof HTMLCanvasElement 或者 instanceof OffscreenCanvas 都为 true 了，太离谱了。